### PR TITLE
Fix UnsupportedOperationException 

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -103,7 +103,6 @@ public class HipChatNotifier extends Notifier {
       public boolean isApplicable(Class<? extends AbstractProject> aClass) {
          return true;
       }
-      
 
       @Override
       public HipChatNotifier newInstance(StaplerRequest sr) {
@@ -135,8 +134,6 @@ public class HipChatNotifier extends Notifier {
       public String getDisplayName() {
          return "HipChat Notifications";
       }
-      
-
    }
 
    public static class HipChatJobProperty extends hudson.model.JobProperty<AbstractProject<?, ?>> {

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.hipchat;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.JobPropertyDescriptor;
@@ -12,6 +13,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -74,6 +76,11 @@ public class HipChatNotifier extends Notifier {
    public HipChatService newHipChatService(String room) {
       return new StandardHipChatService(getAuthToken(), room == null ? getRoom() : room, "Jenkins");
    }
+   
+   @Override
+   public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+       return true;
+   }
 
    @Extension
    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
@@ -96,6 +103,7 @@ public class HipChatNotifier extends Notifier {
       public boolean isApplicable(Class<? extends AbstractProject> aClass) {
          return true;
       }
+      
 
       @Override
       public HipChatNotifier newInstance(StaplerRequest sr) {
@@ -127,6 +135,8 @@ public class HipChatNotifier extends Notifier {
       public String getDisplayName() {
          return "HipChat Notifications";
       }
+      
+
    }
 
    public static class HipChatJobProperty extends hudson.model.JobProperty<AbstractProject<?, ?>> {


### PR DESCRIPTION
This change fixes https://github.com/jlewallen/jenkins-hipchat-plugin/issues/6

Added an empty 'perform' method in HipchatNotifier. If this method is not present, the code falls back to the superclass method in BuildStepCompatibilityLayer, which in turn throws the exception. 
