### PR TITLE
Hipchat notifications

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -46,10 +46,10 @@ public class ActiveNotifier implements FineGrainedNotifier {
       else if(cause != null) {
          MessageBuilder message = new MessageBuilder(notifier, r);
          message.append(cause.getShortDescription());
-         getHipChat(r).publish(message.appendOpenLink().toString());
+         getHipChat(r).publish(message.appendOpenLink().toString(), "green");
       }
       else {
-         getHipChat(r).publish(getBuildStatusMessage(r));
+         getHipChat(r).publish(getBuildStatusMessage(r), "green");
       }
    }
 

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -37,23 +37,27 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
    public void deleted(AbstractBuild r) {}
 
-   public void started(AbstractBuild r) {
-      String changes = getChanges(r);
-      CauseAction cause = r.getAction(CauseAction.class);
+   public void started(AbstractBuild build) {
+      String changes = getChanges(build);
+      CauseAction cause = build.getAction(CauseAction.class);
       if(changes != null) {
-         getHipChat(r).publish(changes);
+         notifyStart(build, changes);
       }
       else if(cause != null) {
-         MessageBuilder message = new MessageBuilder(notifier, r);
+         MessageBuilder message = new MessageBuilder(notifier, build);
          message.append(cause.getShortDescription());
-         getHipChat(r).publish(message.appendOpenLink().toString(), "green");
+         notifyStart(build, message.appendOpenLink().toString());
       }
       else {
-         getHipChat(r).publish(getBuildStatusMessage(r), "green");
+         notifyStart(build, getBuildStatusMessage(build));
       }
    }
 
-   public void finalized(AbstractBuild r) {}
+   private void notifyStart(AbstractBuild build, String message) {
+      getHipChat(build).publish(message, "green");
+   }
+
+    public void finalized(AbstractBuild r) {}
 
    public void completed(AbstractBuild r) {
       getHipChat(r).publish(getBuildStatusMessage(r), getBuildColor(r));

--- a/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
@@ -38,6 +38,7 @@ public class StandardHipChatService implements HipChatService {
             post.addParameter("room_id", roomId);
             post.addParameter("message", message);
             post.addParameter("color", color);
+            post.addParameter("notify", shouldNotify(color));
             client.executeMethod(post);
          }
          catch(HttpException e) {
@@ -50,6 +51,10 @@ public class StandardHipChatService implements HipChatService {
             post.releaseConnection();
          }
       }
+   }
+
+   private String shouldNotify(String color) {
+      return color.equalsIgnoreCase("green") ? "0" : "1";
    }
 
    public void rooms() {


### PR DESCRIPTION
This adds hipchat notifications for messages that aren't green (i.e. failed builds) and makes starting messages green. This addresses issue #9, although there is no configuration mechanism for it...something that I didn't need personally.
