### PR TITLE
pom changes to allow release to jenkins-ci.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 		</license>
 	</licenses>
     <scm>
-        <connection>scm:git:ssh://github.com/darrinholst/jenkins-hipchat-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/darrinholst/jenkins-hipchat-plugin.git</developerConnection>
-        <url>https://github.com/darrinholst/jenkins-hipchat-plugin</url>
+        <connection>scm:git:ssh://github.com/jlewallen/jenkins-hipchat-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jlewallen/jenkins-hipchat-plugin.git</developerConnection>
+        <url>https://github.com/jlewallen/jenkins-hipchat-plugin</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>com.github.jlewallen.jenkins.plugins</groupId>
 	<artifactId>hipchat-plugin</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.0</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
     </distributionManagement>
 
     <scm>
-        <connection>scm:git:ssh://github.com/darrinholst/jenkins-hipchat-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/darrinholst/jenkins-hipchat-plugin.git</developerConnection>
-        <url>https://github.com/darrinholst/jenkins-hipchat-plugin</url>
+        <connection>scm:git:ssh://github.com/jlewallen/jenkins-hipchat-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jlewallen/jenkins-hipchat-plugin.git</developerConnection>
+        <url>https://github.com/jlewallen/jenkins-hipchat-plugin</url>
     </scm>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,14 @@
 		<groupId>org.jvnet.hudson.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<version>1.319</version>
-		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.jlewallen.jenkins.plugins</groupId>
-	<artifactId>jenkins-hipchat-plugin</artifactId>
+	<artifactId>hipchat-plugin</artifactId>
 	<packaging>hpi</packaging>
 	<version>0.1.0-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
-	<url></url>
 	<licenses>
 		<license>
 			<name>MIT license</name>
@@ -21,9 +19,9 @@
 		</license>
 	</licenses>
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/hipchat-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/hipchat-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/hipchat-plugin</url>
+        <connection>scm:git:ssh://github.com/darrinholst/jenkins-hipchat-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/darrinholst/jenkins-hipchat-plugin.git</developerConnection>
+        <url>https://github.com/darrinholst/jenkins-hipchat-plugin</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.1</version>
+	<version>0.1.2-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.1.1</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>com.github.jlewallen.jenkins.plugins</groupId>
 	<artifactId>hipchat-plugin</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.0</version>
+	<version>0.1.1-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.github.jlewallen.jenkins.plugins</groupId>
 	<artifactId>jenkins-hipchat-plugin</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.0-BUILD-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
 	<url></url>
@@ -20,6 +20,17 @@
 			<comments>All source code is under the MIT license.</comments>
 		</license>
 	</licenses>
+    <scm>
+        <connection>scm:git:ssh://github.com/jenkinsci/hipchat-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/hipchat-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/hipchat-plugin</url>
+    </scm>
+    <distributionManagement>
+        <repository>
+            <id>maven.jenkins-ci.org</id>
+            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.hudson.main</groupId>
@@ -36,4 +47,14 @@
 			<version>2.2-hudson-10</version>
 		</dependency>
 	</dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jvnet.hudson.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<version>1.319</version>
 	</parent>
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.jlewallen.jenkins.plugins</groupId>
-	<artifactId>hipchat-plugin</artifactId>
+
+	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
 	<version>0.1.1-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>
+
 	<licenses>
 		<license>
 			<name>MIT license</name>
 			<comments>All source code is under the MIT license.</comments>
 		</license>
 	</licenses>
-    <scm>
-        <connection>scm:git:ssh://github.com/jlewallen/jenkins-hipchat-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jlewallen/jenkins-hipchat-plugin.git</developerConnection>
-        <url>https://github.com/jlewallen/jenkins-hipchat-plugin</url>
-    </scm>
+
     <distributionManagement>
         <repository>
             <id>maven.jenkins-ci.org</id>
             <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
         </repository>
     </distributionManagement>
+
+    <scm>
+        <connection>scm:git:ssh://github.com/darrinholst/jenkins-hipchat-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/darrinholst/jenkins-hipchat-plugin.git</developerConnection>
+        <url>https://github.com/darrinholst/jenkins-hipchat-plugin</url>
+    </scm>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.hudson.main</groupId>
@@ -45,6 +50,7 @@
 			<version>2.2-hudson-10</version>
 		</dependency>
 	</dependencies>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
This should resolve issues #3 and #8

It adds distribution and scm info to the pom. They created a repo at https://github.com/jenkinsci/hipchat-plugin, but you don't have to use it to upload to the maven repository.

I've already pushed the latest up, the wiki is at https://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin, the latest hpi is at http://updates.jenkins-ci.org/download/plugins/hipchat/0.1.1/hipchat.hpi. It should now show up in the jenkins plugin manager also.

If you want to upload it yourself you'll need a jenkins-ci.org account and have them add you to the project. I just posted a message at http://groups.google.com/group/jenkinsci-dev. Then it's just a `mvn release:prepare release:perform -Dusername=... -Dpassword=...`
