### PR TITLE
Change to set charset to avoid mojibake

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
@@ -39,6 +39,7 @@ public class StandardHipChatService implements HipChatService {
             post.addParameter("message", message);
             post.addParameter("color", color);
             post.addParameter("notify", shouldNotify(color));
+            post.getParams().setContentCharset("UTF-8");
             client.executeMethod(post);
          }
          catch(Exception e) {


### PR DESCRIPTION
When Jenkins works on i18n environment, HipChatNotifier causes mojibake (http://en.wikipedia.org/wiki/Mojibake). This is the patch to fix the issue.
