### PR TITLE
Add option for build is back to normal notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+hipchat.iml
 target
 .classpath
+.idea
 .project
 .settings
 bin

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jvnet.hudson.plugins</groupId>
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.2-SNAPSHOT</version>
+	<version>0.1.5-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>
@@ -92,5 +92,19 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -157,10 +157,18 @@ public class HipChatNotifier extends Notifier {
         private boolean notifyNotBuilt;
         private boolean notifyUnstable;
         private boolean notifyFailure;
+        private boolean notifyBackToNormal;
 
 
         @DataBoundConstructor
-        public HipChatJobProperty(String room, boolean startNotification, boolean notifyAborted, boolean notifyFailure, boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable) {
+        public HipChatJobProperty(String room,
+                                  boolean startNotification,
+                                  boolean notifyAborted,
+                                  boolean notifyFailure,
+                                  boolean notifyNotBuilt,
+                                  boolean notifySuccess,
+                                  boolean notifyUnstable,
+                                  boolean notifyBackToNormal) {
             this.room = room;
             this.startNotification = startNotification;
             this.notifyAborted = notifyAborted;
@@ -168,6 +176,7 @@ public class HipChatNotifier extends Notifier {
             this.notifyNotBuilt = notifyNotBuilt;
             this.notifySuccess = notifySuccess;
             this.notifyUnstable = notifyUnstable;
+            this.notifyBackToNormal = notifyBackToNormal;
         }
 
         @Exported
@@ -219,6 +228,11 @@ public class HipChatNotifier extends Notifier {
             return notifyUnstable;
         }
 
+        @Exported
+        public boolean getNotifyBackToNormal() {
+            return notifyBackToNormal;
+        }
+
         @Extension
         public static final class DescriptorImpl extends JobPropertyDescriptor {
             public String getDisplayName() {
@@ -238,7 +252,8 @@ public class HipChatNotifier extends Notifier {
                         sr.getParameter("hipChatNotifyFailure") != null,
                         sr.getParameter("hipChatNotifyNotBuilt") != null,
                         sr.getParameter("hipChatNotifySuccess") != null,
-                        sr.getParameter("hipChatNotifyUnstable") != null);
+                        sr.getParameter("hipChatNotifyUnstable") != null,
+                        sr.getParameter("hipChatNotifyBackToNormal") != null);
             }
         }
     }

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -29,6 +29,10 @@
             <f:checkbox name="hipChatNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
         </f:entry>
 
+        <f:entry title="Notify Back To Normal">
+            <f:checkbox name="hipChatNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
+        </f:entry>
+
     </f:section>
 
 </j:jelly>


### PR DESCRIPTION
Notify on Success is too verbose. Notify on Failure is good, but we also need notifications when the build returns back to normal. This provides that.
