### PR TITLE
Implement Mustache templates for messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target
 .settings
 bin
 work
+
+# IDEA files
+.idea/
+*.iml

--- a/README.markdown
+++ b/README.markdown
@@ -8,34 +8,34 @@ https://github.com/jgp/hudson_campfire_plugin
 
 The plugin has been updated to use [Mustache.java](https://github.com/spullara/mustache.java) to
 generate the HipChat notifications - this allows for easier customisation, as well as adding custom
- build variables to be output.
+build variables to be output.
 
- The default templates are:
+The default templates are:
 
- * Start message: ```{{build.project.displayName}} - {{build.displayName}}: {{trigger}} {{{link}}}```
- * Complete message: ```{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}```
+* Start message: ```{{build.project.displayName}} - {{build.displayName}}: {{trigger}} {{{link}}}```
+* Complete message: ```{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}```
 
- There is also a per-Job configurable "Message suffix" - this is also a Mustache template and is
- used when you want to keep the same template overall and just override something that gets appended
- to the default messages.
+There is also a per-Job configurable "Message suffix" - this is also a Mustache template and is
+used when you want to keep the same template overall and just override something that gets appended
+to the default messages.
 
- ### Available parameters
+### Available parameters
 
- #### Start message
+#### Start message
 
- * **build** - instance of [AbstractBuild](http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html) -
+* **build** - instance of [AbstractBuild](http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html) -
    most of the information comes from this object (eg. ```{{build.project.displayName}}```)
- * **trigger** - a string describing why the build was started - tries to use the "changes" if available, otherwise
+* **trigger** - a string describing why the build was started - tries to use the "changes" if available, otherwise
   the "cause", and finally falls back to the string "Started..."
- * **link** - link to the build in Jenkins - note the triple-bracket to prevent HTML from being escaped
+* **link** - link to the build in Jenkins - note the triple-bracket to prevent HTML from being escaped
 
- #### Completed message
+#### Completed message
 
- * **build** - see above
- * **status** - string describing the state of the build (eg. success, fail, etc)
- * **link** - link to the build in Jenkins
+* **build** - see above
+* **status** - string describing the state of the build (eg. success, fail, etc)
+* **link** - link to the build in Jenkins
 
- ### Using custom build parameters
+### Using custom build parameters
 
- Custom build parameters are available through ```{{build.buildVariables}}``` - for example if you have
- a parameter called ENVIRONMENT then you would use ```{{build.buildVariables.ENVIRONMENT}}```.
+Custom build parameters are available through ```{{build.buildVariables}}``` - for example if you have
+a parameter called ENVIRONMENT then you would use ```{{build.buildVariables.ENVIRONMENT}}```.

--- a/README.markdown
+++ b/README.markdown
@@ -3,3 +3,37 @@
 Started with a fork of the Campfire plugin:
 
 https://github.com/jgp/hudson_campfire_plugin
+
+## Mustache template updates
+
+The plugin has been updated to use [Mustache.java](https://github.com/spullara/mustache.java) to
+generate the HipChat notifications - this allows for easier customisation, as well as adding custom
+ build variables to be output.
+
+ The default templates are:
+
+ * Start message: ```{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}```
+ * Complete message: ```{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}```
+
+ There is also a per-Job configurable "Message suffix" - this is also a Mustache template and is
+ used when you want to keep the same template overall and just override something that gets appended
+ to the default messages.
+
+ **Note** that if you change the messages in the global config you'll have to re-save any Jobs using
+ the default for them to pick up the change!
+
+ ### Available parameters
+
+ #### Start message
+
+ * **build** - instance of [AbstractBuild](http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html) -
+   most of the information comes from this object (eg. ```{{build.project.displayName}}```)
+ * **cause** - the "cause" string as to why the build was started
+ * **changes** - a string describing the changes that caused the build to start
+ * **link** - link to the build in Jenkins - note the triple-bracket to prevent HTML from being escaped
+
+ #### Completed message
+
+ * **build** - see above
+ * **status** - string describing the state of the build (eg. success, fail, etc)
+ * **link** - link to the build in Jenkins

--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ generate the HipChat notifications - this allows for easier customisation, as we
 
  The default templates are:
 
- * Start message: ```{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}```
+ * Start message: ```{{build.project.displayName}} - {{build.displayName}}: {{trigger}} {{{link}}}```
  * Complete message: ```{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}```
 
  There is also a per-Job configurable "Message suffix" - this is also a Mustache template and is
@@ -28,8 +28,8 @@ generate the HipChat notifications - this allows for easier customisation, as we
 
  * **build** - instance of [AbstractBuild](http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html) -
    most of the information comes from this object (eg. ```{{build.project.displayName}}```)
- * **cause** - the "cause" string as to why the build was started
- * **changes** - a string describing the changes that caused the build to start
+ * **trigger** - a string describing why the build was started - tries to use the "changes" if available, otherwise
+  the "cause", and finally falls back to the string "Started..."
  * **link** - link to the build in Jenkins - note the triple-bracket to prevent HTML from being escaped
 
  #### Completed message

--- a/README.markdown
+++ b/README.markdown
@@ -37,3 +37,8 @@ generate the HipChat notifications - this allows for easier customisation, as we
  * **build** - see above
  * **status** - string describing the state of the build (eg. success, fail, etc)
  * **link** - link to the build in Jenkins
+
+ ### Using custom build parameters
+
+ Custom build parameters are available through ```{{build.buildVariables}}``` - for example if you have
+ a parameter called ENVIRONMENT then you would use ```{{build.buildVariables.ENVIRONMENT}}```.

--- a/README.markdown
+++ b/README.markdown
@@ -19,9 +19,6 @@ generate the HipChat notifications - this allows for easier customisation, as we
  used when you want to keep the same template overall and just override something that gets appended
  to the default messages.
 
- **Note** that if you change the messages in the global config you'll have to re-save any Jobs using
- the default for them to pick up the change!
-
  ### Available parameters
 
  #### Start message

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jvnet.hudson.plugins</groupId>
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.3-SNAPSHOT</version>
+	<version>0.1.5-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.447</version>
+        <version>1.500</version>
     </parent>
 
     <!-- keeping original groupId -->
@@ -76,6 +76,11 @@
             <artifactId>commons-logging</artifactId>
             <version>1.0.4</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.8.9</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jvnet.hudson.plugins</groupId>
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.2-SNAPSHOT</version>
+	<version>0.1.3-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -45,10 +45,23 @@ public class ActiveNotifier implements FineGrainedNotifier {
         String changes = getChanges(build);
         CauseAction cause = build.getAction(CauseAction.class);
 
+        String trigger;
+        if (changes != null)
+        {
+            trigger = changes;
+        }
+        else if (cause != null)
+        {
+            trigger = cause.getShortDescription();
+        }
+        else
+        {
+            trigger = "Starting...";
+        }
+
         Map<String, Object> messageParams = new HashMap<String,Object>();
         messageParams.put("build", build);
-        messageParams.put("cause", cause);
-        messageParams.put("changes", changes);
+        messageParams.put("trigger", trigger);
         messageParams.put("link", getOpenLink(build));
 
         HipChatNotifier.HipChatJobProperty jobProperty = getJobPropertyForBuild(build);

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -50,11 +50,10 @@ public class ActiveNotifier implements FineGrainedNotifier {
         messageParams.put("changes", changes);
         messageParams.put("link", MessageBuilder.getOpenLink(notifier, build));
 
-        if (notifier.getMessageTemplateStarted() == null)
+        if (notifier.getMessageTemplateStarted() == null || "".equals(notifier.getMessageTemplateStarted()))
         {
-            logger.warning("Started message template is not set!");
+            logger.warning("Started message template is not set, using default");
             notifier.setMessageTemplateStarted("{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}");
-            return;
         }
 
         notifyStart(build, applyMessageTemplate(notifier.getMessageTemplateStarted(), messageParams));
@@ -78,9 +77,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 || (result == Result.SUCCESS && jobProperty.getNotifySuccess())
                 || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
 
-            if (notifier.getMessageTemplateCompleted() == null)
+            if (notifier.getMessageTemplateCompleted() == null || "".equals(notifier.getMessageTemplateCompleted()))
             {
-                logger.warning("Completed message template is not set!");
+                logger.warning("Completed message template is not set, using default");
                 notifier.setMessageTemplateCompleted("{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}");
             }
 

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -81,7 +81,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             if (notifier.getMessageTemplateCompleted() == null)
             {
                 logger.warning("Completed message template is not set!");
-                notifier.setMessageTemplateCompleted("{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}");
+                notifier.setMessageTemplateCompleted("{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}");
             }
 
             getHipChat(r).publish(getBuildStatusMessage(r), getBuildColor(r));
@@ -150,6 +150,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         Map<String,Object> messageParams = new HashMap<String, Object>();
         messageParams.put("build", r);
         messageParams.put("status", MessageBuilder.getStatusMessage(r));
+        messageParams.put("link", MessageBuilder.getOpenLink(notifier, r));
 
         return applyMessageTemplate(notifier.getMessageTemplateCompleted(), messageParams);
     }

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -92,7 +92,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
             String messageTemplate = getMessageTemplate(jobProperty.getMessageTemplateCompleted(),
                     jobProperty.getMessageTemplateSuffix(),
-                    "{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}");
+                    "{{build.project.displayName}} - {{build.displayName}}: {{{status}}} after {{build.durationString}} {{{link}}}");
 
             Map<String,Object> messageParams = new HashMap<String, Object>();
             messageParams.put("build", r);

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -155,11 +155,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
     private String getMessageTemplate(String baseTemplate, String suffixTemplate, String defaultTemplate)
     {
         StringBuilder template = new StringBuilder();
-        if (baseTemplate == null || "".equals(baseTemplate))
+        if (baseTemplate == null || StringUtils.isBlank(baseTemplate))
         {
             template.append(defaultTemplate);
         }
-        if (suffixTemplate != null && !"".equals(suffixTemplate)) {
+        if (suffixTemplate != null && StringUtils.isNotBlank(suffixTemplate)) {
             template.append(" ");
             template.append(suffixTemplate);
         }

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -191,7 +191,10 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
     private String getOpenLink(AbstractBuild build)
     {
-        String url = notifier.getBuildServerUrl() + build.getUrl();
-        return new StringBuilder("(<a href='").append(url).append("'>Open</a>)").toString();
+        StringBuilder builder = new StringBuilder("(<a href='");
+        builder.append(notifier.getBuildServerUrl());
+        builder.append(build.getUrl());
+        builder.append("'>Open</a>)");
+        return builder.toString();
     }
 }

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -1,5 +1,8 @@
 package jenkins.plugins.hipchat;
 
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -10,10 +13,9 @@ import hudson.scm.ChangeLogSet.AffectedFile;
 import hudson.scm.ChangeLogSet.Entry;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.*;
 import java.util.logging.Logger;
 
 @SuppressWarnings("rawtypes")
@@ -22,10 +24,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
     private static final Logger logger = Logger.getLogger(HipChatListener.class.getName());
 
     HipChatNotifier notifier;
+    MustacheFactory mustacheFactory;
 
     public ActiveNotifier(HipChatNotifier notifier) {
         super();
         this.notifier = notifier;
+        this.mustacheFactory = new DefaultMustacheFactory();
     }
 
     private HipChatService getHipChat(AbstractBuild r) {
@@ -41,15 +45,19 @@ public class ActiveNotifier implements FineGrainedNotifier {
         String changes = getChanges(build);
         CauseAction cause = build.getAction(CauseAction.class);
 
-        if (changes != null) {
-            notifyStart(build, changes);
-        } else if (cause != null) {
-            MessageBuilder message = new MessageBuilder(notifier, build);
-            message.append(cause.getShortDescription());
-            notifyStart(build, message.appendOpenLink().toString());
-        } else {
-            notifyStart(build, getBuildStatusMessage(build));
+        Map<String, Object> messageParams = new HashMap<String,Object>();
+        messageParams.put("build", build);
+        messageParams.put("changes", changes);
+        messageParams.put("link", MessageBuilder.getOpenLink(notifier, build));
+
+        if (notifier.getMessageTemplateStarted() == null)
+        {
+            logger.warning("Started message template is not set!");
+            notifier.setMessageTemplateStarted("{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}");
+            return;
         }
+
+        notifyStart(build, applyMessageTemplate(notifier.getMessageTemplateStarted(), messageParams));
     }
 
     private void notifyStart(AbstractBuild build, String message) {
@@ -69,6 +77,13 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 || (result == Result.NOT_BUILT && jobProperty.getNotifyNotBuilt())
                 || (result == Result.SUCCESS && jobProperty.getNotifySuccess())
                 || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
+
+            if (notifier.getMessageTemplateCompleted() == null)
+            {
+                logger.warning("Completed message template is not set!");
+                notifier.setMessageTemplateCompleted("{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}");
+            }
+
             getHipChat(r).publish(getBuildStatusMessage(r), getBuildColor(r));
         }
 
@@ -97,12 +112,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
             authors.add(entry.getAuthor().getDisplayName());
         }
         MessageBuilder message = new MessageBuilder(notifier, r);
-        message.append("Started by changes from ");
+        message.append("by changes from ");
         message.append(StringUtils.join(authors, ", "));
         message.append(" (");
         message.append(files.size());
         message.append(" file(s) changed)");
-        return message.appendOpenLink().toString();
+        return message.toString();
     }
 
     static String getBuildColor(AbstractBuild r) {
@@ -116,12 +131,29 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
     }
 
-    String getBuildStatusMessage(AbstractBuild r) {
-        MessageBuilder message = new MessageBuilder(notifier, r);
-        message.appendStatusMessage();
-        message.appendDuration();
-        return message.appendOpenLink().toString();
+    String applyMessageTemplate(String messageTemplate, Map<String,Object> messageParams)
+    {
+        StringWriter messageWriter = new StringWriter();
+
+        String actualTemplate = messageTemplate;
+        if (notifier.getMessageTemplateSuffix() != null)
+        {
+            actualTemplate += " " + notifier.getMessageTemplateSuffix();
+        }
+
+        Mustache mustache = this.mustacheFactory.compile(new StringReader(actualTemplate), "message");
+        mustache.execute(messageWriter, messageParams);
+        return messageWriter.toString();
     }
+
+    String getBuildStatusMessage(AbstractBuild r) {
+        Map<String,Object> messageParams = new HashMap<String, Object>();
+        messageParams.put("build", r);
+        messageParams.put("status", MessageBuilder.getStatusMessage(r));
+
+        return applyMessageTemplate(notifier.getMessageTemplateCompleted(), messageParams);
+    }
+
 
     public static class MessageBuilder {
         private StringBuffer message;
@@ -171,9 +203,15 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return this;
         }
 
-        public MessageBuilder appendOpenLink() {
+        static String getOpenLink(HipChatNotifier notifier, AbstractBuild build)
+        {
             String url = notifier.getBuildServerUrl() + build.getUrl();
-            message.append(" (<a href='").append(url).append("'>Open</a>)");
+            return new StringBuilder("(<a href='").append(url).append("'>Open</a>)").toString();
+        }
+
+        public MessageBuilder appendOpenLink() {
+
+            message.append(" " + getOpenLink(notifier, build));
             return this;
         }
 

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -47,13 +47,14 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
         Map<String, Object> messageParams = new HashMap<String,Object>();
         messageParams.put("build", build);
+        messageParams.put("cause", cause);
         messageParams.put("changes", changes);
         messageParams.put("link", getOpenLink(build));
 
         if (notifier.getMessageTemplateStarted() == null || "".equals(notifier.getMessageTemplateStarted()))
         {
             logger.warning("Started message template is not set, using default");
-            notifier.setMessageTemplateStarted("{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}");
+            notifier.setMessageTemplateStarted("{{build.project.displayName}} - {{build.displayName}}: {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}");
         }
 
         notifyStart(build, applyMessageTemplate(notifier.getMessageTemplateStarted(), messageParams));
@@ -111,7 +112,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             authors.add(entry.getAuthor().getDisplayName());
         }
         StringBuilder message = new StringBuilder();
-        message.append("by changes from ");
+        message.append("Started by changes from ");
         message.append(StringUtils.join(authors, ", "));
         message.append(" (");
         message.append(files.size());

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -25,6 +25,9 @@ public class HipChatNotifier extends Notifier {
     private String buildServerUrl;
     private String room;
     private String sendAs;
+    private String messageTemplateStarted;
+    private String messageTemplateCompleted;
+    private String messageTemplateSuffix;
 
     @Override
     public DescriptorImpl getDescriptor() {
@@ -63,13 +66,43 @@ public class HipChatNotifier extends Notifier {
         this.sendAs = sendAs;
     }
 
+    public String getMessageTemplateStarted() {
+        return messageTemplateStarted;
+    }
+
+    public void setMessageTemplateStarted(String messageTemplateStarted) {
+        this.messageTemplateStarted = messageTemplateStarted;
+    }
+
+    public String getMessageTemplateCompleted() {
+        return messageTemplateCompleted;
+    }
+
+    public void setMessageTemplateCompleted(String messageTemplateCompleted) {
+        this.messageTemplateCompleted = messageTemplateCompleted;
+    }
+
+    public String getMessageTemplateSuffix() {
+        return messageTemplateSuffix;
+    }
+
+    public void setMessageTemplateSuffix(String messageTemplateSuffix) {
+        this.messageTemplateSuffix = messageTemplateSuffix;
+    }
+
+
+
     @DataBoundConstructor
-    public HipChatNotifier(final String authToken, final String room, String buildServerUrl, final String sendAs) {
+    public HipChatNotifier(final String authToken, final String room, String buildServerUrl, final String sendAs,
+                           final String messageTemplateStarted, final String messageTemplateCompleted, final String messageTemplateSuffix) {
         super();
         this.authToken = authToken;
         this.buildServerUrl = buildServerUrl;
         this.room = room;
         this.sendAs = sendAs;
+        this.messageTemplateStarted = messageTemplateStarted;
+        this.messageTemplateCompleted = messageTemplateCompleted;
+        this.messageTemplateSuffix = messageTemplateSuffix;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -91,6 +124,9 @@ public class HipChatNotifier extends Notifier {
         private String room;
         private String buildServerUrl;
         private String sendAs;
+        private String messageTemplateStarted;
+        private String messageTemplateCompleted;
+        private String messageTemplateSuffix;
 
         public DescriptorImpl() {
             load();
@@ -112,6 +148,18 @@ public class HipChatNotifier extends Notifier {
             return sendAs;
         }
 
+        public String getMessageTemplateStarted() {
+            return messageTemplateStarted;
+        }
+
+        public String getMessageTemplateCompleted() {
+            return messageTemplateCompleted;
+        }
+
+        public String getMessageTemplateSuffix() {
+            return messageTemplateSuffix;
+        }
+
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }
@@ -122,7 +170,10 @@ public class HipChatNotifier extends Notifier {
             if (buildServerUrl == null) buildServerUrl = sr.getParameter("hipChatBuildServerUrl");
             if (room == null) room = sr.getParameter("hipChatRoom");
             if (sendAs == null) sendAs = sr.getParameter("hipChatSendAs");
-            return new HipChatNotifier(token, room, buildServerUrl, sendAs);
+            if (messageTemplateStarted == null) messageTemplateStarted = sr.getParameter("hipChatMessageTemplateStarted");
+            if (messageTemplateCompleted == null) messageTemplateCompleted = sr.getParameter("hipChatMessageTemplateCompleted");
+            if (messageTemplateSuffix == null) messageTemplateSuffix = sr.getParameter("hipChatMessageTemplateSuffix");
+            return new HipChatNotifier(token, room, buildServerUrl, sendAs, messageTemplateStarted, messageTemplateCompleted, messageTemplateSuffix);
         }
 
         @Override
@@ -131,11 +182,14 @@ public class HipChatNotifier extends Notifier {
             room = sr.getParameter("hipChatRoom");
             buildServerUrl = sr.getParameter("hipChatBuildServerUrl");
             sendAs = sr.getParameter("hipChatSendAs");
+            messageTemplateStarted = sr.getParameter("hipChatMessageTemplateStarted");
+            messageTemplateCompleted = sr.getParameter("hipChatMessageTemplateCompleted");
+
             if (buildServerUrl != null && !buildServerUrl.endsWith("/")) {
                 buildServerUrl = buildServerUrl + "/";
             }
             try {
-                new HipChatNotifier(token, room, buildServerUrl, sendAs);
+                new HipChatNotifier(token, room, buildServerUrl, sendAs, messageTemplateStarted, messageTemplateCompleted, messageTemplateSuffix);
             } catch (Exception e) {
                 throw new FormException("Failed to initialize notifier - check your global notifier configuration settings", e, "");
             }
@@ -157,11 +211,16 @@ public class HipChatNotifier extends Notifier {
         private boolean notifyNotBuilt;
         private boolean notifyUnstable;
         private boolean notifyFailure;
-
+        private String messageTemplateStarted;
+        private String messageTemplateCompleted;
+        private String messageTemplateSuffix;
 
         @DataBoundConstructor
-        public HipChatJobProperty(String room, boolean startNotification, boolean notifyAborted, boolean notifyFailure, boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable) {
+        public HipChatJobProperty(String room, String messageTemplatedStarted, String messageTemplateCompleted, String messageTemplateSuffix, boolean startNotification, boolean notifyAborted, boolean notifyFailure, boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable) {
             this.room = room;
+            this.messageTemplateStarted = messageTemplatedStarted;
+            this.messageTemplateCompleted = messageTemplateCompleted;
+            this.messageTemplateSuffix = messageTemplateSuffix;
             this.startNotification = startNotification;
             this.notifyAborted = notifyAborted;
             this.notifyFailure = notifyFailure;
@@ -183,6 +242,21 @@ public class HipChatNotifier extends Notifier {
         @Exported
         public boolean getNotifySuccess() {
             return notifySuccess;
+        }
+
+        @Exported
+        public String getMessageTemplateStarted() {
+            return messageTemplateStarted;
+        }
+
+        @Exported
+        public String getMessageTemplateCompleted() {
+            return messageTemplateCompleted;
+        }
+
+        @Exported
+        public String getMessageTemplateSuffix() {
+            return messageTemplateSuffix;
         }
 
         @Override
@@ -233,6 +307,9 @@ public class HipChatNotifier extends Notifier {
             @Override
             public HipChatJobProperty newInstance(StaplerRequest sr, JSONObject formData) throws hudson.model.Descriptor.FormException {
                 return new HipChatJobProperty(sr.getParameter("hipChatProjectRoom"),
+                        sr.getParameter("hipChatMessageTemplateStarted"),
+                        sr.getParameter("hipChatMessageTemplateCompleted"),
+                        sr.getParameter("hipChatMessageTemplateSuffix"),
                         sr.getParameter("hipChatStartNotification") != null,
                         sr.getParameter("hipChatNotifyAborted") != null,
                         sr.getParameter("hipChatNotifyFailure") != null,

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -5,15 +5,15 @@
       		<f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
     	</f:entry>
 
-        <f:entry title="Started message template" help="">
+        <f:entry title="Build Started template" help="${rootURL}/plugin/hipchat/help-projectConfig-hipChatMessageTemplateStarted.html">
             <f:textbox name="hipChatMessageTemplateStarted" value="${instance.getMessageTemplateStarted()}" />
         </f:entry>
 
-        <f:entry title="Completed message template" help="">
+        <f:entry title="Build Completed template" help="${rootURL}/plugin/hipchat/help-projectConfig-hipChatMessageTemplateCompleted.html">
             <f:textbox name="hipChatMessageTemplateCompleted" value="${instance.getMessageTemplateCompleted()}" />
         </f:entry>
 
-        <f:entry title="Message template suffix" help="">
+        <f:entry title="Template suffix" help="${rootURL}/plugin/hipchat/help-projectConfig-hipChatMessageTemplateSuffix.html">
             <f:textbox name="hipChatMessageTemplateSuffix" value="${instance.getMessageTemplateSuffix()}" />
         </f:entry>
 

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -5,6 +5,18 @@
       		<f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
     	</f:entry>
 
+        <f:entry title="Started message template" help="">
+            <f:textbox name="hipChatMessageTemplateStarted" value="${instance.getMessageTemplateStarted()}" />
+        </f:entry>
+
+        <f:entry title="Completed message template" help="">
+            <f:textbox name="hipChatMessageTemplateCompleted" value="${instance.getMessageTemplateCompleted()}" />
+        </f:entry>
+
+        <f:entry title="Message template suffix" help="">
+            <f:textbox name="hipChatMessageTemplateSuffix" value="${instance.getMessageTemplateSuffix()}" />
+        </f:entry>
+
     	<f:entry title="Notify Build Start">
       		<f:checkbox name="hipChatStartNotification" value="true" checked="${instance.getStartNotification()}"/>
     	</f:entry>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -24,11 +24,11 @@
     <f:entry title="Send As" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatSendAs.html">
         <f:textbox name="hipChatSendAs" value="${descriptor.getSendAs()}" />
     </f:entry>
-    <f:entry title="Started message template" help="">
+    <f:entry title="Build Started template" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatMessageTemplateStarted.html">
         <f:textbox name="hipChatMessageTemplateStarted" value="${descriptor.getMessageTemplateStarted()}"
          default="{{build.project.displayName}} - {{build.displayName}}: {{trigger}} {{{link}}}" />
     </f:entry>
-    <f:entry title="Completed message template" help="">
+    <f:entry title="Build Completed template" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatMessageTemplateCompleted.html">
         <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"
          default="{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}" />
     </f:entry>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -30,7 +30,7 @@
     </f:entry>
     <f:entry title="Completed message template" help="">
         <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"
-         default="{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}" />
+         default="{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}" />
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -30,7 +30,7 @@
     </f:entry>
     <f:entry title="Build Completed template" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatMessageTemplateCompleted.html">
         <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"
-         default="{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}} {{{link}}}" />
+         default="{{build.project.displayName}} - {{build.displayName}}: {{{status}}} after {{build.durationString}} {{{link}}}" />
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -26,7 +26,7 @@
     </f:entry>
     <f:entry title="Started message template" help="">
         <f:textbox name="hipChatMessageTemplateStarted" value="${descriptor.getMessageTemplateStarted()}"
-         default="{{build.project.displayName}} - {{build.displayName}}: {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}" />
+         default="{{build.project.displayName}} - {{build.displayName}}: {{trigger}} {{{link}}}" />
     </f:entry>
     <f:entry title="Completed message template" help="">
         <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -24,5 +24,13 @@
     <f:entry title="Send As" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatSendAs.html">
         <f:textbox name="hipChatSendAs" value="${descriptor.getSendAs()}" />
     </f:entry>
+    <f:entry title="Started message template" help="">
+        <f:textbox name="hipChatMessageTemplateStarted" value="${descriptor.getMessageTemplateStarted()}"
+         default="{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}" />
+    </f:entry>
+    <f:entry title="Completed message template" help="">
+        <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"
+         default="{{build.project.displayName}} - {{build.displayName}}: {{status}} after {{build.durationString}}" />
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -26,7 +26,7 @@
     </f:entry>
     <f:entry title="Started message template" help="">
         <f:textbox name="hipChatMessageTemplateStarted" value="${descriptor.getMessageTemplateStarted()}"
-         default="{{build.project.displayName}} - {{build.displayName}}: Started {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}" />
+         default="{{build.project.displayName}} - {{build.displayName}}: {{#cause}}{{cause.shortDescription}}{{/cause}} {{#changes}}{{changes}}{{/changes}} {{{link}}}" />
     </f:entry>
     <f:entry title="Completed message template" help="">
         <f:textbox name="hipChatMessageTemplateCompleted" value="${descriptor.getMessageTemplateCompleted()}"

--- a/src/main/webapp/help-globalConfig-hipChatMessageTemplateCompleted.html
+++ b/src/main/webapp/help-globalConfig-hipChatMessageTemplateCompleted.html
@@ -1,0 +1,14 @@
+<div>
+    <p>Specify a <a href="http://mustache.github.com/" target="_blank">Mustache</a> template that will be used to generate the
+        notification message sent to HipChat when a build is completed</p>
+    <p>Available parameters are:
+    <ul>
+    <li><strong>build</strong>: the <a href="http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html" target="_blank">AbstractBuild</a>
+        instance referring to the build - contains useful properties such as <em>build.project.displayName</em></li>
+    <li><strong>status</strong>: a string representing the build completion status</li>
+    <li><strong>link</strong>: a link to the Jenkins build</li>
+    </ul>
+    </p>
+    <p>You can set a global template here, or specify a template per-job. If neither is specified then a default will
+        be used.</p>
+</div>

--- a/src/main/webapp/help-globalConfig-hipChatMessageTemplateStarted.html
+++ b/src/main/webapp/help-globalConfig-hipChatMessageTemplateStarted.html
@@ -1,0 +1,14 @@
+<div>
+    <p>Specify a <a href="http://mustache.github.com/" target="_blank">Mustache</a> template that will be used to generate the
+        notification message sent to HipChat when a build is started</p>
+    <p>Available parameters are:
+    <ul>
+    <li><strong>build</strong>: the <a href="http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html" target="_blank">AbstractBuild</a>
+        instance referring to the build - contains useful properties such as <em>build.project.displayName</em></li>
+    <li><strong>trigger</strong>: a string representing why the build was started</li>
+    <li><strong>link</strong>: a link to the Jenkins build</li>
+    </ul>
+    </p>
+    <p>You can set a global template here, or specify a template per-job. If neither is specified then a default will
+        be used.</p>
+</div>

--- a/src/main/webapp/help-projectConfig-hipChatMessageTemplateCompleted.html
+++ b/src/main/webapp/help-projectConfig-hipChatMessageTemplateCompleted.html
@@ -1,0 +1,12 @@
+<div>
+    <p>Specify a <a href="http://mustache.github.com/" target="_blank">Mustache</a> template that will be used to generate the
+        notification message sent to HipChat when a build is completed</p>
+    <p>Available parameters are:
+    <ul>
+    <li><strong>build</strong>: the <a href="http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html" target="_blank">AbstractBuild</a>
+        instance referring to the build - contains useful properties such as <em>build.project.displayName</em></li>
+    <li><strong>status</strong>: a string representing the build completion status</li>
+    <li><strong>link</strong>: a link to the Jenkins build</li>
+    </ul>
+    </p>
+</div>

--- a/src/main/webapp/help-projectConfig-hipChatMessageTemplateStarted.html
+++ b/src/main/webapp/help-projectConfig-hipChatMessageTemplateStarted.html
@@ -1,0 +1,12 @@
+<div>
+    <p>Specify a <a href="http://mustache.github.com/" target="_blank">Mustache</a> template that will be used to generate the
+        notification message sent to HipChat when a build is started</p>
+    <p>Available parameters are:
+    <ul>
+    <li><strong>build</strong>: the <a href="http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html" target="_blank">AbstractBuild</a>
+        instance referring to the build - contains useful properties such as <em>build.project.displayName</em></li>
+    <li><strong>trigger</strong>: a string representing why the build was started</li>
+    <li><strong>link</strong>: a link to the Jenkins build</li>
+    </ul>
+    </p>
+</div>

--- a/src/main/webapp/help-projectConfig-hipChatMessageTemplateSuffix.html
+++ b/src/main/webapp/help-projectConfig-hipChatMessageTemplateSuffix.html
@@ -1,0 +1,13 @@
+<div>
+    <p>Specify a <a href="http://mustache.github.com/" target="_blank">Mustache</a> template that will be appended to the end of the
+        Build Started and Build Completed templates.</p>
+
+    <p>This can be used when you want a global base default template but just want to configure the last part of a
+    template on a per-job basis.  This is particularly useful when you want to include build parameters in the status
+    messages.</p>
+
+    <p>The variables available to this template is the same as for the template it is appended to (eg. Start or Complete).  Of particular
+    use might be build parameters which are available via <em>build.buildVariables</em>
+    (eg. <em>build.buildVariables.ENVIRONMENT</em>)</p>
+
+</div>


### PR DESCRIPTION
A number of people in issue #12  have asked for the ability to customise the messages, such as adding build parameters etc.  By using Mustache templates for build messages this can now be done.

This is quite a large change, and probably not as heavily tested as it should be. It probably needs some unit tests too.  I am also not a Java developer, but "know" the language, so I might not have done everything optimally.

The README has been updates with information as to how the templates work, and the defaults should keep the messages the same as they were pre-Mustache.

This doesn't actually solve the original issue as it doesn't add the git branch name, and if the branch name isn't available through the accessible instance variables then it won't, I haven't checked.

It's probably a good start though!
