### PR TITLE
Apply build variables to HipChat configuration

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -31,7 +31,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
     private HipChatService getHipChat(AbstractBuild r) {
         AbstractProject<?, ?> project = r.getProject();
         String projectRoom = Util.fixEmpty(project.getProperty(HipChatNotifier.HipChatJobProperty.class).getRoom());
-        return notifier.newHipChatService(projectRoom);
+        return notifier.newHipChatService(projectRoom, r);
     }
 
     public void deleted(AbstractBuild r) {


### PR DESCRIPTION
In particular this allows specifying the auth token in configuration as
${SECRET_HIPCHAT_TOKEN}, and defining it somewhere else, like with
Jenkins' global password support, so that it isn't stored in the job's
config.xml.

To test this I added a global password named HIPCHAT_AUTH_TOKEN in
global configuration and referenced it as ${HIPCHAT_AUTH_TOKEN} from the
global HipChat configuration. Then I enabled global passwords as
environment variables and HipChat notifications in a build notifications
in a job, built the job, and verified that HipChat was notified.
