### PR TITLE
Append custom message to notification, configurable per Project (includes var evaluation).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jvnet.hudson.plugins</groupId>
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.5-SNAPSHOT</version>
+	<version>0.1.6-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -99,7 +99,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             culpritNames.add(culprit.getFullName());
         }
 
-        return "Who's to blame? " + StringUtils.join(culpritNames, ", ");
+        return "Committers since last Success: " + StringUtils.join(culpritNames, ", ");
     }
 
     static String getBuildColor(AbstractBuild r) {

--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -35,29 +35,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     public void started(AbstractBuild build) {
-        MessageBuilder message = new MessageBuilder(notifier, build);
-        String changes = getChanges(build);
-        CauseAction cause = build.getAction(CauseAction.class);
         AbstractProject<?, ?> project = build.getProject();
-        String customMessage = Util.fixEmpty(project.getProperty(HipChatNotifier.HipChatJobProperty.class).getCustomMessage());
-
-        if (changes != null) {
-            message.append(changes);
-            message.appendCustomMessage(customMessage, build);
-            notifyStart(build, message.toString());
-        } else if (cause != null) {
-            message.append(cause.getShortDescription());
-            message.appendOpenLink();
-            message.appendCustomMessage(customMessage, build);
-            notifyStart(build, message.toString());
-        } else {
-            notifyStart(build, getBuildStatusMessage(build));
+        HipChatNotifier.HipChatJobProperty jobProperty = project.getProperty(HipChatNotifier.HipChatJobProperty.class);
+        if (MessageBuilder.shouldNotify(jobProperty.getStartNotification(), jobProperty.getConditionalNotify(), build)) {
+            getHipChat(build).publish(getBuildStatusMessage(build), "green");
         }
-
-    }
-
-    private void notifyStart(AbstractBuild build, String message) {
-        getHipChat(build).publish(message, "green");
     }
 
     public void finalized(AbstractBuild r) {
@@ -69,12 +51,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
         Result result = r.getResult();
         AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
         Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
-        if ((result == Result.ABORTED && jobProperty.getNotifyAborted())
-                || (result == Result.FAILURE && jobProperty.getNotifyFailure())
-                || (result == Result.NOT_BUILT && jobProperty.getNotifyNotBuilt())
-                || (result == Result.SUCCESS && previousResult == Result.FAILURE && jobProperty.getNotifyBackToNormal())
-                || (result == Result.SUCCESS && jobProperty.getNotifySuccess())
-                || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
+        if ((result == Result.ABORTED && MessageBuilder.shouldNotify(jobProperty.getNotifyAborted(), jobProperty.getConditionalNotify(), r))
+                || (result == Result.FAILURE && MessageBuilder.shouldNotify(jobProperty.getNotifyFailure(), jobProperty.getConditionalNotify(), r))
+                || (result == Result.NOT_BUILT && MessageBuilder.shouldNotify(jobProperty.getNotifyNotBuilt(), jobProperty.getConditionalNotify(), r))
+                || (result == Result.SUCCESS && previousResult == Result.FAILURE && MessageBuilder.shouldNotify(jobProperty.getNotifyBackToNormal(), jobProperty.getConditionalNotify(), r))
+                || (result == Result.SUCCESS && MessageBuilder.shouldNotify(jobProperty.getNotifySuccess(), jobProperty.getConditionalNotify(), r))
+                || (result == Result.UNSTABLE && MessageBuilder.shouldNotify(jobProperty.getNotifyUnstable(), jobProperty.getConditionalNotify(), r))) {
             getHipChat(r).publish(getBuildStatusMessage(r), getBuildColor(r));
         }
     }
@@ -121,14 +103,26 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
     }
 
-    String getBuildStatusMessage(AbstractBuild r) {
-        AbstractProject<?, ?> project = r.getProject();
+    String getBuildStatusMessage(AbstractBuild build) {
+        String changes = getChanges(build);
+        CauseAction cause = build.getAction(CauseAction.class);
+        AbstractProject<?, ?> project = build.getProject();
         String customMessage = Util.fixEmpty(project.getProperty(HipChatNotifier.HipChatJobProperty.class).getCustomMessage());
-        MessageBuilder message = new MessageBuilder(notifier, r);
+        MessageBuilder message = new MessageBuilder(notifier, build);
+
         message.appendStatusMessage();
-        message.appendDuration();
-        message.appendOpenLink();
-        return message.appendCustomMessage(customMessage, r).toString();
+        if (!build.isBuilding()) message.appendDuration();
+
+        if (changes != null) {
+            message.append(changes);
+        } else if (cause != null) {
+            message.append(cause.getShortDescription());
+            message.appendOpenLink();
+        } else {
+            message.appendOpenLink();
+        }
+
+        return message.appendCustomMessage(customMessage, build).toString();
     }
 
     public static class MessageBuilder {
@@ -144,6 +138,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
 
         public MessageBuilder appendStatusMessage() {
+            message.append("Build status: ");
             message.append(getStatusMessage(build));
             return this;
         }
@@ -207,10 +202,19 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return message.toString();
         }
 
-        private String getParameterString(String original, AbstractBuild<?, ?> build) {
-            ParametersAction parameters = build.getAction(ParametersAction.class);
+        public static boolean shouldNotify(boolean jobNotifyProperty, String conditionalProperty, AbstractBuild r) {
+            boolean blnConditionalProperty = true;
+            conditionalProperty = MessageBuilder.getParameterString(conditionalProperty, r);
+            if (conditionalProperty.equalsIgnoreCase("true") || conditionalProperty.equalsIgnoreCase("false")) {
+                blnConditionalProperty = Boolean.valueOf(conditionalProperty);
+            }
+            return jobNotifyProperty && blnConditionalProperty;
+        }
+
+        public static String getParameterString(String original, AbstractBuild<?, ?> r) {
+            ParametersAction parameters = r.getAction(ParametersAction.class);
             if (parameters != null) {
-                original = parameters.substitute(build, original);
+                original = parameters.substitute(r, original);
             }
 
             return original;

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -144,7 +144,7 @@ public class HipChatNotifier extends Notifier {
         private boolean notifyUnstable;
         private boolean notifyFailure;
         private boolean notifyBackToNormal;
-
+        private String customMessage;
 
         @DataBoundConstructor
         public HipChatJobProperty(String room,
@@ -154,7 +154,8 @@ public class HipChatNotifier extends Notifier {
                                   boolean notifyNotBuilt,
                                   boolean notifySuccess,
                                   boolean notifyUnstable,
-                                  boolean notifyBackToNormal) {
+                                  boolean notifyBackToNormal,
+                                  String customMessage) {
             this.room = room;
             this.startNotification = startNotification;
             this.notifyAborted = notifyAborted;
@@ -163,6 +164,7 @@ public class HipChatNotifier extends Notifier {
             this.notifySuccess = notifySuccess;
             this.notifyUnstable = notifyUnstable;
             this.notifyBackToNormal = notifyBackToNormal;
+            this.customMessage = customMessage;
         }
 
         @Exported
@@ -219,6 +221,11 @@ public class HipChatNotifier extends Notifier {
             return notifyBackToNormal;
         }
 
+        @Exported
+        public String getCustomMessage() {
+            return customMessage;
+        }
+
         @Extension
         public static final class DescriptorImpl extends JobPropertyDescriptor {
             public String getDisplayName() {
@@ -239,7 +246,8 @@ public class HipChatNotifier extends Notifier {
                         sr.getParameter("hipChatNotifyNotBuilt") != null,
                         sr.getParameter("hipChatNotifySuccess") != null,
                         sr.getParameter("hipChatNotifyUnstable") != null,
-                        sr.getParameter("hipChatNotifyBackToNormal") != null);
+                        sr.getParameter("hipChatNotifyBackToNormal") != null,
+                        sr.getParameter("hipChatCustomMessage"));
             }
         }
     }

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -144,6 +144,7 @@ public class HipChatNotifier extends Notifier {
         private boolean notifyUnstable;
         private boolean notifyFailure;
         private boolean notifyBackToNormal;
+        private String conditionalNotify;
         private String customMessage;
 
         @DataBoundConstructor
@@ -155,6 +156,7 @@ public class HipChatNotifier extends Notifier {
                                   boolean notifySuccess,
                                   boolean notifyUnstable,
                                   boolean notifyBackToNormal,
+                                  String conditionalNotify,
                                   String customMessage) {
             this.room = room;
             this.startNotification = startNotification;
@@ -164,6 +166,7 @@ public class HipChatNotifier extends Notifier {
             this.notifySuccess = notifySuccess;
             this.notifyUnstable = notifyUnstable;
             this.notifyBackToNormal = notifyBackToNormal;
+            this.conditionalNotify = conditionalNotify;
             this.customMessage = customMessage;
         }
 
@@ -222,6 +225,11 @@ public class HipChatNotifier extends Notifier {
         }
 
         @Exported
+        public String getConditionalNotify() {
+            return conditionalNotify;
+        }
+
+        @Exported
         public String getCustomMessage() {
             return customMessage;
         }
@@ -247,6 +255,7 @@ public class HipChatNotifier extends Notifier {
                         sr.getParameter("hipChatNotifySuccess") != null,
                         sr.getParameter("hipChatNotifyUnstable") != null,
                         sr.getParameter("hipChatNotifyBackToNormal") != null,
+                        sr.getParameter("hipChatConditionalNotify"),
                         sr.getParameter("hipChatCustomMessage"));
             }
         }

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -33,6 +33,10 @@
             <f:checkbox name="hipChatNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
         </f:entry>
 
+        <f:entry title="Custom Message">
+            <f:textbox name="hipChatCustomMessage" value="${instance.getCustomMessage()}"/>
+        </f:entry>
+
     </f:section>
 
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -1,46 +1,41 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Project Room">
+    		<f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
+    </f:entry>
 
-	<f:section title="HipChat Notifications">
-    	<f:entry title="Project Room">
-      		<f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
-    	</f:entry>
+    <f:entry title="Notify Build Start">
+    		<f:checkbox name="hipChatStartNotification" value="true" checked="${instance.getStartNotification()}"/>
+    </f:entry>
 
-    	<f:entry title="Notify Build Start">
-      		<f:checkbox name="hipChatStartNotification" value="true" checked="${instance.getStartNotification()}"/>
-    	</f:entry>
+    <f:entry title="Notify Aborted">
+        <f:checkbox name="hipChatNotifyAborted" value="true" checked="${instance.getNotifyAborted()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Aborted">
-            <f:checkbox name="hipChatNotifyAborted" value="true" checked="${instance.getNotifyAborted()}"/>
-        </f:entry>
+    <f:entry title="Notify Failure">
+        <f:checkbox name="hipChatNotifyFailure" value="true" checked="${instance.getNotifyFailure()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Failure">
-            <f:checkbox name="hipChatNotifyFailure" value="true" checked="${instance.getNotifyFailure()}"/>
-        </f:entry>
+    <f:entry title="Notify Not Built">
+        <f:checkbox name="hipChatNotifyNotBuilt" value="true" checked="${instance.getNotifyNotBuilt()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Not Built">
-            <f:checkbox name="hipChatNotifyNotBuilt" value="true" checked="${instance.getNotifyNotBuilt()}"/>
-        </f:entry>
+    <f:entry title="Notify Success">
+        <f:checkbox name="hipChatNotifySuccess" value="true" checked="${instance.getNotifySuccess()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Success">
-            <f:checkbox name="hipChatNotifySuccess" value="true" checked="${instance.getNotifySuccess()}"/>
-        </f:entry>
+    <f:entry title="Notify Unstable">
+        <f:checkbox name="hipChatNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Unstable">
-            <f:checkbox name="hipChatNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
-        </f:entry>
+    <f:entry title="Notify Back To Normal">
+        <f:checkbox name="hipChatNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
+    </f:entry>
 
-        <f:entry title="Notify Back To Normal">
-            <f:checkbox name="hipChatNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
-        </f:entry>
+    <f:entry title="Conditional Notify" help="${rootURL}/plugin/hipchat/help-config-hipChatConditionalNotify.html">
+        <f:textbox name="hipChatConditionalNotify" value="${instance.getConditionalNotify()}"/>
+    </f:entry>
 
-        <f:entry title="Conditional Notify" help="${rootURL}/plugin/hipchat/help-config-hipChatConditionalNotify.html">
-            <f:textbox name="hipChatConditionalNotify" value="${instance.getConditionalNotify()}"/>
-        </f:entry>
-
-        <f:entry title="Custom Message" help="${rootURL}/plugin/hipchat/help-config-hipChatCustomMessage.html">
-            <f:textbox name="hipChatCustomMessage" value="${instance.getCustomMessage()}"/>
-        </f:entry>
-
-    </f:section>
-
+    <f:entry title="Custom Message" help="${rootURL}/plugin/hipchat/help-config-hipChatCustomMessage.html">
+        <f:textbox name="hipChatCustomMessage" value="${instance.getCustomMessage()}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -33,7 +33,11 @@
             <f:checkbox name="hipChatNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
         </f:entry>
 
-        <f:entry title="Custom Message">
+        <f:entry title="Conditional Notify" help="${rootURL}/plugin/hipchat/help-config-hipChatConditionalNotify.html">
+            <f:textbox name="hipChatConditionalNotify" value="${instance.getConditionalNotify()}"/>
+        </f:entry>
+
+        <f:entry title="Custom Message" help="${rootURL}/plugin/hipchat/help-config-hipChatCustomMessage.html">
             <f:textbox name="hipChatCustomMessage" value="${instance.getCustomMessage()}"/>
         </f:entry>
 

--- a/src/main/webapp/help-config-hipChatConditionalNotify.html
+++ b/src/main/webapp/help-config-hipChatConditionalNotify.html
@@ -1,0 +1,4 @@
+<div xmlns="http://www.w3.org/1999/html">
+	<p>Specify weather notifications should be sent out based on build parameters.  If parameters evaluate to true, then all notifications specified above will be sent.  Otherwise, the notifications will not be sent.</p>
+	<p>One example of this parameter's use is to add a build parameter to your jenkins job named 'Send_Notification'.  This parameter can then be used here to allow person running the job to determine if notifications can be sent.  User would put ${Send_Notification} in this field.</p>
+</div>

--- a/src/main/webapp/help-config-hipChatCustomMessage.html
+++ b/src/main/webapp/help-config-hipChatCustomMessage.html
@@ -1,0 +1,3 @@
+<div xmlns="http://www.w3.org/1999/html">
+	<p>Optionally specify a custom message to append to your HipChat notification.  You may use variables in your message using the standing format.  e.g. ${var_name}</p>
+</div>


### PR DESCRIPTION
I reviewed the existing pull requires and non of them really accomplished what I was trying to do.  The Mustache templates change is much more than I need and the 'Add custom message variable' is too simple (note configurable per project and doesn't eval variables).  Here is what I was trying to accomplish:

1) Give the option to append a custom message to messages sent to hipchat.
2) If the custom message references variables (i.e. ${var_name}), evaluate them.
3) The custom message need to be configurable on a per-project basis.

The PR accomplishes this.  I see this as being a nice option along side the other PR currently being considered.

Please let me know what you think.  Thanks!
