### PR TITLE
Change "Started" notification color to yellow

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -50,7 +50,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     private void notifyStart(AbstractBuild build, String message) {
-        getHipChat(build).publish(message, "green");
+        getHipChat(build).publish(message, "yellow");
     }
 
     public void finalized(AbstractBuild r) {


### PR DESCRIPTION
Hi, I'd like to propose changing color of "Started" notification to yellow.

Since "Green" represents "all is well", I'm often mistaken that "Build Started" notification is "Build Success".
Other types of notification, such as GitHub's service hook, sends their notification with yellow color.

I think yellow is more neutral than green and suite for "Started" notification.
