### PR TITLE
Use BuildStepMonitor.NONE

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -59,7 +59,7 @@ public class HipChatNotifier extends Notifier {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     public HipChatService newHipChatService(final String room) {


### PR DESCRIPTION
Otherwise when using concurrent builds, a later one may gratuitously block waiting for an earlier one to finish.

By the way please, please, please use @jenkinsci as the authoritative version of your plugin. Or at the very least keep that clone up to date. Or failing that, delete the obsolete clone so contributors do not have to waste time filing PRs against a two-year-old copy.
