### PR TITLE
Fixed Problem With SCMs that do not implement getAffectedFiles()

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -84,7 +84,15 @@ public class ActiveNotifier implements FineGrainedNotifier {
             Entry entry = (Entry) o;
             logger.info("Entry " + o);
             entries.add(entry);
-            files.addAll(entry.getAffectedFiles());
+            try {
+            	//getAffectedFiles() can return UnsupportedOperationException if the SCM do not implement the interface (TFS does not)
+            	files.addAll(entry.getAffectedFiles());
+            } catch (UnsupportedOperationException e){
+            	//return null if SCM doe snot support getAffectedFiles()
+            	logger.info(e.getMessage());
+            	return null;
+            }
+            
         }
         if (entries.isEmpty()) {
             logger.info("Empty change...");


### PR DESCRIPTION
When working with TFS hipchat was causing the build to fail because it does not implement the getAffectedFiles method. The method threw an UnsupportedOperationException causing the build to fail. It now catches the exception and just returns null and continues the build. If the SCM gets updated to allow getAffectedFiles then this code should still work. 
