### PR TITLE
Fixed Problem With SCMs that do not implement getAffectedFiles()

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -84,7 +84,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
             Entry entry = (Entry) o;
             logger.info("Entry " + o);
             entries.add(entry);
-            files.addAll(entry.getAffectedFiles());
+            try{
+            	files.addAll(entry.getAffectedFiles());
+            } catch (UnsupportedOperationException e){
+            	logger.info(e.getMessage());
+            	return null;
+            }
         }
         if (entries.isEmpty()) {
             logger.info("Empty change...");


### PR DESCRIPTION
With the getAffectedFiles method it returns an error when the SCM does not implement it. This happened with TFS. It causes the builds to fail. With these changes it will now return null and continue with the build. 
