### PR TITLE
Use the project's full display name in the message

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -165,7 +165,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
 
         private MessageBuilder startMessage() {
-            message.append(build.getProject().getDisplayName());
+            message.append(build.getProject().getFullDisplayName());
             message.append(" - ");
             message.append(build.getDisplayName());
             message.append(" ");


### PR DESCRIPTION
Previously it was using display name. The difference is for projects
nested in folders. getDisplayName returns the last segment there,
whereas getFullDisplayName includes all the parent folders as well,
separated by ». For projects not in folders, they're identical.

We have several builds with the same final segment name
that are only different based on the folder they're in. This works much
better for that.
