### PR TITLE
Added the ability to specify the HipChat HOST so it can work with private HipChat servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jvnet.hudson.plugins</groupId>
 	<artifactId>hipchat</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.1.5-SNAPSHOT</version>
+	<version>0.1.5.1-SNAPSHOT</version>
 	<name>Jenkins HipChat Plugin</name>
 	<description>A Build status publisher that notifies channels on a HipChat server</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin</url>

--- a/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
@@ -19,8 +19,11 @@ public class StandardHipChatService implements HipChatService {
     private String[] roomIds;
     private String from;
 
-    public StandardHipChatService(String token, String roomId, String from) {
+    public StandardHipChatService(String host, String token, String roomId, String from) {
         super();
+        if (host != null && !String.trim().isEmpty()) {
+            this.host = host;
+        }
         this.token = token;
         this.roomIds = roomId.split(",");
         this.from = from;
@@ -31,8 +34,9 @@ public class StandardHipChatService implements HipChatService {
     }
 
     public void publish(String message, String color) {
+        logger.info("Publishing messages to HipChat server [" + host + "]...");
         for (String roomId : roomIds) {
-            logger.info("Posting: " + from + " to " + roomId + ": " + message + " " + color);
+            logger.info("`" + from + "` says to room `" + roomId + "`: `" + message + "` in the color `" + color + "`");
             HttpClient client = getHttpClient();
             String url = "https://" + host + "/v1/rooms/message?auth_token=" + token;
             PostMethod post = new PostMethod(url);
@@ -55,6 +59,8 @@ public class StandardHipChatService implements HipChatService {
                 post.releaseConnection();
             }
         }
+        
+        logger.info("Done publishing messages to HipChat server");
     }
     
     private HttpClient getHttpClient() {

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -12,6 +12,9 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global HipChat Notifier Settings">
+    <f:entry title="HipChat Server" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatHost.html">
+        <f:textbox name="hipChatHost" value="${descriptor.getHost()}" />
+    </f:entry>
     <f:entry title="API Token" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatToken.html">
         <f:textbox name="hipChatToken" value="${descriptor.getToken()}" />
     </f:entry>

--- a/src/main/webapp/help-globalConfig-hipChatHost.html
+++ b/src/main/webapp/help-globalConfig-hipChatHost.html
@@ -1,0 +1,4 @@
+<div>
+    <p>This is the full URL to the HipChat server to communicate with.</p>
+    <p>The default is the public server of `api.hipchat.com`</p>
+</div>

--- a/src/test/java/jenkins/plugins/hipchat/StandardHipChatServiceTest.java
+++ b/src/test/java/jenkins/plugins/hipchat/StandardHipChatServiceTest.java
@@ -11,8 +11,7 @@ public class StandardHipChatServiceTest {
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardHipChatService service = new StandardHipChatService("token", "room", "from");
-        service.setHost("hostvaluethatwillcausepublishtofail");
+        StandardHipChatService service = new StandardHipChatService("hostvaluethatwillcausepublishtofail", "token", "room", "from");
         service.publish("message");
     }
 }


### PR DESCRIPTION
We are hosting HipChat privately at work and needed to be able to specify the host. Since private hosting is now supported it should probably make it's way into the official plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jlewallen/jenkins-hipchat-plugin/68)
<!-- Reviewable:end -->
